### PR TITLE
Remove DeepLink whitelist notice

### DIFF
--- a/deployment-plan.md
+++ b/deployment-plan.md
@@ -60,6 +60,11 @@
 3. 验证网站是否正常访问
 4. 根据需要进一步优化配置
 
+### 最近文档变更记录
+
+- 移除 DeepLink 英文页面中关于 DApp 白名单申请表单的提示文案（`docs/mobile/deeplink.en.md`）
+- 移除 DeepLink 中文页面中关于 DApp 白名单申请表单的提示文案（`docs/mobile/deeplink.zh.md`）
+
 ## 文件结构
 
 ```

--- a/docs/mobile/deeplink.en.md
+++ b/docs/mobile/deeplink.en.md
@@ -10,11 +10,6 @@ img {
 }
 </style>
 
-Process Flowchart
-
-Please be aware that only DApps that have been added to the whitelist will be able to establish a successful connection with TronLink. Kindly fill out the whitelist request form here: [Start](https://docs.google.com/forms/d/e/1FAIpQLSdFmYGxVZzwCSsvmdOTq064sxWD22STYth1g5GO5zn3OrB5Jw/viewform?usp=sf_link)
-
-
 ## Open Wallet
 
 ### Launch TronLink wallet via DeepLink

--- a/docs/mobile/deeplink.zh.md
+++ b/docs/mobile/deeplink.zh.md
@@ -9,11 +9,6 @@ img {
 }
 </style>
 
-操作流程图
-
-注意：只有已添加至白名单的 DApp 才能成功连接至 TronLink。请在此处填写白名单申请：[填写表单](https://docs.google.com/forms/d/e/1FAIpQLSdFmYGxVZzwCSsvmdOTq064sxWD22STYth1g5GO5zn3OrB5Jw/viewform?usp=sf_link)
-
-
 ## 打开钱包
 
 使用 DeepLink 方式唤起钱包


### PR DESCRIPTION
Remove whitelist notice section from DeepLink EN page.
Remove corresponding whitelist notice from DeepLink ZH page.
Update deployment plan document change log.